### PR TITLE
usage: Update for workload storage changes

### DIFF
--- a/ciao/usage/tutorial.md
+++ b/ciao/usage/tutorial.md
@@ -103,8 +103,8 @@ requirements:
 cloud_init: redis-master-cloud.yaml
 disks:
   - source:
-       service: image
-       id: "046aa079-7614-494b-9044-06587510213d"
+       type: image
+       source: "046aa079-7614-494b-9044-06587510213d"
     ephemeral: true
     bootable: true
 ```
@@ -135,8 +135,8 @@ requirements:
 cloud_init: redis-slave-cloud.yaml
 disks:
   - source:
-       service: image
-       id: "046aa079-7614-494b-9044-06587510213d"
+       type: image
+       source: "046aa079-7614-494b-9044-06587510213d"
     ephemeral: true
     bootable: true
 ```

--- a/ciao/usage/workloads.md
+++ b/ciao/usage/workloads.md
@@ -61,8 +61,8 @@ vm_type: qemu
 fw_type: legacy
 disks:
   - source:
-       service: image
-       id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+       type: image
+       source: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
     ephemeral: true
     bootable: true
 ```
@@ -107,11 +107,12 @@ image by including a `source` definition.
 disks:
 - bootable: true
   source:
-     service: volume
-     id: "9c858de5-fdd3-42d8-925e-2fdc60768d24"
+     type: volume
+     source: "9c858de5-fdd3-42d8-925e-2fdc60768d24"
 ```
 
-Valid values for the source `service` field are `image` or `volume`
+Valid values for the source `type` field are `image` or `volume`. The `source`
+field for images can refer to either the image ID or name.
 
 Workload definitions must also contain default values for resources
 that the workload will need to use when it runs. There are two resources


### PR DESCRIPTION
The field names in the source structure have changed and we now support
image names as well as image IDs.

See ciao-project/ciao#1595.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>