### PR TITLE
usage: Update scripting documentation for ciao

### DIFF
--- a/ciao/usage/scripting.md
+++ b/ciao/usage/scripting.md
@@ -4,29 +4,30 @@ permalink: scripting.html
 keywords: CIAO, command line, tool, scripting, templates
 ---
 
-## Scripting with ciao-cli
+## Scripting with ciao
 
-Most of the ciao-cli commands contain a list or show subcommand, e.g.,
+The cli has two commands that present information to the user: show and list
 
 ```shell
-$ ciao-cli instance list
+$ ciao list instances
 ```
 
 By default, these commands format their output in a style that is pleasing to
 the human eye.  For example,
 
 ```shell
-$ ciao-cli instance show --instance cef5b810-5ffb-4dee-ab95-29748869afb6
-
-    UUID: cef5b810-5ffb-4dee-ab95-29748869afb6
-    Status: active
-    Private IP: 172.16.0.3
-    MAC Address: 02:00:ac:10:00:03
-    CN UUID: fe4fa7da-0c46-46cf-9205-28c9d675aa5a
-    Image UUID: 73a86d7e-93c0-480e-9c41-ab42f69b7799
-    Tenant UUID: f452bbc7-5076-44d5-922c-3b9d2ce1503f
-    SSH IP: 198.51.100.75
-    SSH Port: 33003
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6
+PrivateAddresses: [{172.16.0.2 02:00:ac:10:00:02}]        
+Created:          2018-01-04 16:15:51.767182887 +0000 UTC 
+WorkloadID:       22368826-b7ba-4f97-8400-57276b1c383c    
+NodeID:           4879795e-18f0-4c18-9be3-eb21e5c6df12    
+ID:               45e56df2-350b-49f0-b394-f949cdf6b3b6    
+Name:                                                     
+Volumes:          [af75d901-2dcd-41fc-9827-3b30d320577c]  
+Status:           active                                  
+TenantID:         b5df368f-c097-437c-90d2-620a5d1bb0b0    
+SSHIP:            198.51.100.71                           
+SSHPort:          33002    
 ```
 
 However, this is not always what we want, particularly if we are writing a
@@ -35,7 +36,7 @@ programmatically retrieve the ssh connection details for the above instance.
 Using the command above we'd need to do some scripting to ignore the first 7
 lines and extract the IP and port number from lines 8 and 9.  Nasty.
 
-Luckily all the ciao-cli show and list commands accept a -f option which
+Luckily the ciao show and list commands accept a -f option which
 is specified along with a [Go template](https://golang.org/pkg/text/template/).
 These templates are little programs that can be used to extract the specific
 data we are interested in.  For example, to extract the SSH IP and port numbers
@@ -43,52 +44,47 @@ we would issue the following command.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance cef5b810-5ffb-4dee-ab95-29748869afb6 -f '{{.SSHIP}}:{{.SSHPort}}'
-
-198.51.100.75:33003
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{.SSHIP}}:{{.SSHPort}}'
+198.51.100.71:33002
 ```
 {% endraw %}
 
 No parsing required.
 
-Check the help for each individual show and list command to discover which
+Check the help for each individual show and list subcommand to discover which
 fields, e.g., SSHIP, are supported.  For example,
 
 ```shell
+$ ciao help show instance
+Show information about an instance
 
-$ ciao-cli instance show --help
+Usage:
+  ciao show instance ID [flags]
 
-usage: ciao-cli [options] instance show [flags]
+Flags:
+  -h, --help   help for instance
 
-Print detailed information about an instance
+Global Flags:
+  -f, --template string   Template used to format output
 
-The show flags are:
-
-  -f string
-    	Template used to format output
-  -instance string
-    	Instance UUID
-
-The template passed to the -f option operates on a
+When using the template flag the following structure is provided:
 
 struct {
-	HostID   string                               // ID of the host node
-	ID       string                               // Instance UUID
-	TenantID string                               // Tenant UUID
-	Flavor   struct {
-		ID string                             // Workload UUID
-	}
-	Image struct {
-		ID string                             // Backing image UUID
-	}
-	Status    string                              // Instance status
-	Addresses struct {
-		Private []struct {
-			Addr               string     // Instance IP address
-			OSEXTIPSMACMacAddr string     // Instance MAC address
-		}
-	}
-	SSHIP   string                                // Instance SSH IP address
+	PrivateAddresses []struct {
+		Addr    string `json:"addr"`
+		MacAddr string `json:"mac_addr"`
+	} `json:"private_addresses"`
+	Created    time.Time `json:"created"`
+	WorkloadID string    `json:"workload_id"`
+	NodeID     string    `json:"node_id"`
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Volumes    []string  `json:"volumes"`
+	Status     string    `json:"status"`
+	TenantID   string    `json:"tenant_id"`
+	SSHIP      string    `json:"ssh_ip"`
+	SSHPort    int       `json:"ssh_port"`
+}
 	SSHPort int                                   // Instance SSH Port
 }
 ```
@@ -96,16 +92,16 @@ struct {
 ## Template Cheat Sheet
 
 Let's look at a few more examples of how we can use templates to extract
-information from the ciao-cli command.  Looking at the help of the ciao-cli
-instance show command shown above we can see that ciao-cli passes a structure
+information from the ciao command.  Looking at the help of the ciao
+show instance command shown above we can see that ciao passes a structure
 to the template passed to the -f option.  The members of this structure can be
 accessed inside template code by prefixing their name with '.'.  For example
 the following command prints out the ID of an instance.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{.ID}}'
-80efbb0a-23ae-4d47-8e74-39fb18497c85
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{.ID}}'
+45e56df2-350b-49f0-b394-f949cdf6b3b6
 ```
 {% endraw %}
 
@@ -114,9 +110,9 @@ confusing.  We can fix this by including a newline character directly in the tem
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{.ID}}
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{.ID}}
 '
-80efbb0a-23ae-4d47-8e74-39fb18497c85
+45e56df2-350b-49f0-b394-f949cdf6b3b6
 ```
 {% endraw %}
 
@@ -124,8 +120,8 @@ or by using the println function
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{println .ID}}'
-80efbb0a-23ae-4d47-8e74-39fb18497c85
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{println .ID}}'
+45e56df2-350b-49f0-b394-f949cdf6b3b6
 ```
 {% endraw %}
 
@@ -134,19 +130,20 @@ of the instance.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{.ID}} ({{.Status}}) {{.SSHIP}}:{{.SSHPort}}{{println}}'
-80efbb0a-23ae-4d47-8e74-39fb18497c85 (active) 198.51.100.96:33002
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{.ID}} ({{.Status}}) {{.SSHIP}}:{{.SSHPort}}{{println}}'
+45e56df2-350b-49f0-b394-f949cdf6b3b6 (active) 198.51.100.71:33002
+
 ```
 {% endraw %}
 
-Now let's take a look at the Addresses field.  This field is a structure that
-contains a slice of structures.  We can gain access to this slice as follows
-.Addresses.Private.  Let's output the slice to see what happens.
+ Now let's take a look at the PrivateAddresses field. This field is a slice of
+ structures. We can gain access to this slice as follows .PrivateAddresses
+ Let's output the slice to see what happens.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{println .Addresses.Private}}'
-[{172.16.0.2 02:00:ac:10:00:02  0}]
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{println .PrivateAddresses}}'
+[{172.16.0.2 02:00:ac:10:00:02}]
 ```
 {% endraw %}
 
@@ -156,21 +153,21 @@ of each structure we would type:
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{range .Addresses.Private}}{{println .OSEXTIPSMACMacAddr}}{{end}}'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{range .PrivateAddresses}}{{println .MacAddr}}{{end}}'
 02:00:ac:10:00:02
 ```
 {% endraw %}
 
 Note that inside the {{range}}{{end}} tags the meaning of the . cursor changes.  Rather than
 referring to the entire structure passed to template it refers to an individual element
-of the .Addresses.Private slice.  If you want to access a field of the top level structure
+of the .PrivateAddresses slice.  If you want to access a field of the top level structure
 inside the range statement you need to use the $ operator.  For example, the following
-command prints the HostID of the instance before it prints each MAC address.
+command prints the NodeID of the instance before it prints each MAC address.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{range .Addresses.Private}}{{$.HostID}} : {{println .OSEXTIPSMACMacAddr}}{{end}}'
-c483c178-2109-4a54-bf00-98cbf4bfa58b : 02:00:ac:10:00:02
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{range .PrivateAddresses}}{{$.NodeID}} : {{println .MacAddr}}{{end}}'
+4879795e-18f0-4c18-9be3-eb21e5c6df12 : 02:00:ac:10:00:02
 ```
 {% endraw %}
 
@@ -179,17 +176,17 @@ we can access it directly.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{println (index .Addresses.Private 0).OSEXTIPSMACMacAddr}}'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{println (index .PrivateAddresses 0).MacAddr}}'
 02:00:ac:10:00:02
 ```
 {% endraw %}
 
-If you find the expression (index .Addresses.Private 0).OSEXTIPSMACMacAddr a little confusing
+If you find the expression (index .PrivateAddresses 0).MacAddr a little confusing
 you can split things up by introducing a new variable.
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{$addr := index .Addresses.Private 0}}{{println $addr.OSEXTIPSMACMacAddr}}'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{$addr := index .PrivateAddresses 0}}{{println $addr.MacAddr}}'
 02:00:ac:10:00:02
 ```
 {% endraw %}
@@ -198,14 +195,13 @@ Here the $addr variable becomes the first element of the slice.  $addr itself is
 so we can use the . operator to access its fields.
 
 However, there's a problem with this approach.  We don't know in advance how many entries
-are present in the .Addresses.Private slice.  If we try to index an element that doesn't
+are present in the .PrivateAddresses slice.  If we try to index an element that doesn't
 exist we'll get an error.  For example,
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{$addr := index .Addresses.Private 1}}{{println $addr.OSEXTIPSMACMacAddr}}'
-F1117 10:54:29.246108    8776 template.go:30] ciao-cli FATAL: template: instance-show:1:11: executing "instance-show" at <index .Addresses.Pri...>: error calling index: index out of range: 1
-goroutine 1 [running]:
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{$addr := index .PrivateAddresses 1}}{{println $addr.MacAddr}}'
+Error: Error generating template output: template: :1:11: executing "" at <index .PrivateAddres...>: error calling index: index out of range: 1
 ```
 {% endraw %}
 
@@ -213,36 +209,37 @@ We can use the if statement to prevent us from accessing non-existing elements, 
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{if gt (len .Addresses.Private) 1}}{{$addr := index .Addresses.Private 1}}{{println $addr.OSEXTIPSMACMacAddr}}{{end}}'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{if gt (len .PrivateAddresses) 1}}{{$addr := index .PrivateAddresses 1}}{{println $addr.MacAddr}}{{end}}'
 ```
 {% endraw %}
 
 The command prints nothing as our if statement evaluates to false.  There's only one element in
-.Addresses.Private slice.
+.PrivateAddresses slice.
 
-Note in the previous example we use the rather unwieldy .Addresses.Private twice.  We can eliminate
+Note in the previous example we use the rather unwieldy .PrivateAddresses twice.  We can eliminate
 the repetition using the with statement, e.g.,
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{with .Addresses.Private}}{{if gt (len .) 1}}{{$addr := index . 1}}{{println $addr.OSEXTIPSMACMacAddr}}{{end}}{{end}}'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '{{with .PrivateAddresses}}{{if gt (len .) 1}}{{$addr := index . 1}}{{println $addr.MacAddr}}{{end}}{{end}}'
 ```
 {% endraw %}
 
 Inside the with statement the . cursor takes on a new meaning.  It becomes assigned to the
-value of .Addresses.Private.
+value of .PrivateAddresses.
 
 The example above is getting a little big to fit onto one line.  We might find it easier to
 read if it were split onto multiple lines, e.g.,
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{with .Addresses.Private}}
-   {{if gt (len .) 1}}
-     {{$addr := index . 1}}{{println $addr.OSEXTIPSMACMacAddr}}
-   {{end}}
- {{end}}
-'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '
+{{with .PrivateAddresses}}
+	{{if gt (len .) 1}}
+		{{$addr := index . 1}}
+		{{println $addr.MacAddr}}
+	{{end}}
+{{end}}'
 ```
 {% endraw %}
 
@@ -252,42 +249,41 @@ the }}s{% endraw %}, e.g.,
 
 {% raw %}
 ```shell
-$ ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{with .Addresses.Private}}
-  {{- if gt (len .) 1}}
-    {{- $addr := index . 1}}{{println $addr.OSEXTIPSMACMacAddr}}
-  {{- end}}
-{{- end -}}
-'
+$ ciao show instance 45e56df2-350b-49f0-b394-f949cdf6b3b6 -f '
+{{- with .PrivateAddresses}}
+	{{- if gt (len .) 1}}
+		{{- $addr := index . 1}}
+		{{- println $addr.MacAddr}}
+	{{- end}}
+{{- end -}}'
 ```
 {% endraw %}
 
 The '-'s gobble up the white space that occurs before the {% raw %}{{- and after the -}}{% endraw %}.
 
-Here's one final example.  Let's take a look at the help for the ciao-cli workload list
+Here's one final example.  Let's take a look at the help for the ciao list workloads 
 command.
 
 ```shell
-$ ciao-cli workload list --help
-usage: ciao-cli [options] workload list
+$ ciao help list workloads
+List workloads.
 
-List all workloads
+Usage:
+  ciao list workloads [flags]
 
-  -f string
-    	Template used to format output
+Flags:
+  -h, --help   help for workloads
 
-The template passed to the -f option operates on a
+Global Flags:
+  -f, --template string   Template used to format output
+
+When using the template flag the following structure is provided:
 
 []struct {
-	OSFLVDISABLEDDisabled  bool    // Not used
-	Disk                   string  // Backing images associated with workload
-	OSFLVEXTDATAEphemeral  int     // Not currently used
-	OsFlavorAccessIsPublic bool    // Indicates whether the workload is available to all tenants
-	ID                     string  // ID of the workload
-	Links                  []Link  // Not currently used
-	Name                   string  // Name of the workload
-	RAM                    int     // Amount of RAM allocated to instances of this workload
-	Swap                   string  // Not currently used
-	Vcpus                  int     // Number of Vcpus allocated to instances of this workload
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	CPUs int    `json:"vcpus"`
+	Mem  int    `json:"ram"`
 }
 ```
 
@@ -297,8 +293,8 @@ So to determine the number of workloads available we would type.
 
 {% raw %}
 ```shell
-$ ciao-cli workload list -f '{{println (len .)}}'
-5
+$ ciao list workloads -f '{{println (len .)}}'
+4
 ```
 {% endraw %}
 
@@ -306,11 +302,10 @@ To output the names of each workload we might do
 
 {% raw %}
 ```shell
-$ ciao-cli workload list -f '{{range .}}{{println .Name}}{{end}}'
-Fedora 24 Cloud
-Clear Cloud
-Docker Debian latest
-Docker Iperf
-Boot Fedora24 from created volume based on image
+$ ciao list workloads -f '{{range .}}{{println .Name}}{{end}}'
+Clear Linux test VM
+Debian latest test container
+Ubuntu latest test container
+Ubuntu test VM
 ```
 {% endraw %}


### PR DESCRIPTION
Update the scripting documentation to reflect the change from ciao-cli
to ciao.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>